### PR TITLE
Allow slicing the PartialPipeline

### DIFF
--- a/tests/pipeline/test_slice.py
+++ b/tests/pipeline/test_slice.py
@@ -1,0 +1,21 @@
+from sklearn.feature_extraction.text import HashingVectorizer
+from sklearn.linear_model import LogisticRegression
+
+from tokenwiser.textprep import Cleaner, Identity, HyphenTextPrep
+from tokenwiser.pipeline import PartialPipeline, make_partial_pipeline, make_concat
+
+
+def test_can_slice_pipeline():
+    """If we slice a pipeline, we should get a new pipeline object"""
+    pipe1 = make_partial_pipeline(
+        Cleaner(),
+        make_concat(
+            Identity(),
+            HyphenTextPrep(),
+        ),
+        HashingVectorizer(),
+        LogisticRegression()
+    )
+
+    slice = pipe1[:-1]
+    assert isinstance(slice, PartialPipeline)

--- a/tokenwiser/pipeline/_pipe.py
+++ b/tokenwiser/pipeline/_pipe.py
@@ -20,10 +20,6 @@ class PartialPipeline(Pipeline):
     assert results == expected
     ```
     """
-
-    def __init__(self, steps):
-        super().__init__(steps=steps)
-
     def partial_fit(self, X, y=None, classes=None, **kwargs):
         """
         Fits the components, but allow for batches.


### PR DESCRIPTION
Normal sklearn pipelines allow getting out sub-pipelines by using the sequence slicing notation. I use this frequently to check and debug the data right before it goes into the model. This doesn't work for PartialPipeline because some arguments are missing in the constructor. 

This PR currently only contains a test case illustrating the behaviour. Do you want to support slicing for partial pipelines as well? Then I'll update the PR with the required changes.